### PR TITLE
exclude draft content from generated files

### DIFF
--- a/build.go
+++ b/build.go
@@ -75,7 +75,6 @@ func Build(entryResolver EntryResolver, dependencyManager DependencyManager, hug
 		logs.Process("Executing build process")
 		buffer := bytes.NewBuffer(nil)
 		args := []string{
-			"-D",
 			"--destination", "output",
 		}
 

--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -76,7 +76,7 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				"  Installing Hugo",
 				"",
 				"  Executing build process",
-				"    Running 'hugo -D --destination output'",
+				"    Running 'hugo --destination output'",
 			))
 		})
 	})

--- a/integration/testdata/default_site/content/posts/my-first-post.md
+++ b/integration/testdata/default_site/content/posts/my-first-post.md
@@ -1,6 +1,5 @@
 ---
 title: "My First Post"
 date: 2021-03-05T11:01:10-05:00
-draft: true
 ---
 


### PR DESCRIPTION
The files generated by the buildpack shouldn't include draft post by default.